### PR TITLE
Fix TS function args definition for loadScriptPromised

### DIFF
--- a/loadScriptPromised.d.ts
+++ b/loadScriptPromised.d.ts
@@ -1,2 +1,2 @@
 // Needs a name due to a bug in the ESLint TS parser
-export default function defaultExport(url: string): Promise<void>;
+export default function defaultExport(url: string, attrs?: object): Promise<void>;


### PR DESCRIPTION
Per the function signature for loadScriptPromised it accepts an optional object that it maps to attributes on the script tag. However, this is not included in the TS definition, causing errors in the consumers of this package.